### PR TITLE
Rescale move scores

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -90,7 +90,7 @@ impl Attacks {
 
 // All named collections of constants
 c_enum!(u8, Bound, LOWER = 0, EXACT = 1, UPPER = 2);
-c_enum!(i32, Score, MAX = 30000, MATE = Self::MAX - 256, HASH = 300000, MVV_LVA = 32768, PROMO = 50000, KILLER = 40000);
+c_enum!(i32, Score, MAX = 30000, MATE = Self::MAX - 256, HASH = 3000000, MVV_LVA = 65536, PROMO = 70000, KILLER = 69000);
 c_enum!(usize, Side, WHITE = 0, BLACK = 1);
 c_enum!(usize, Piece, EMPTY = 0, PAWN = 2, KNIGHT = 3, BISHOP = 4, ROOK = 5, QUEEN = 6, KING = 7);
 c_enum!(u8, Flag, QUIET = 0, DBL = 1, KS = 2, QS = 3, CAP = 4, ENP = 5, PROMO = 8, QPR = 11, NPC = 12, QPC = 15);


### PR DESCRIPTION
Score of dev vs master: 1593 - 1433 - 1971  [0.516] 4997
...      dev playing White: 1080 - 456 - 963  [0.625] 2499
...      dev playing Black: 513 - 977 - 1008  [0.407] 2498
...      White vs Black: 2057 - 969 - 1971  [0.609] 4997
Elo difference: 11.1 +/- 7.5, LOS: 99.8 %, DrawRatio: 39.4 %
