### PR TITLE
Reduced Passed Pawn Moves Less

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
         match *commands.first().unwrap_or(&"oops") {
             "uci" => {
                 println!("id name akimbo {}\nid author Jamie Whiting", env!("CARGO_PKG_VERSION"));
+                println!("option name Threads type spin default 1 min 1 max 1");
                 println!("option name Hash type spin default 16 min 1 max 1024");
                 println!("option name Clear Hash type button");
                 println!("uciok");

--- a/src/position.rs
+++ b/src/position.rs
@@ -10,7 +10,7 @@ macro_rules! bitloop {($bb:expr, $sq:ident, $func:expr) => {
 
 #[derive(Clone, Copy, Default)]
 pub struct Position {
-    bb: [u64; 8],
+    pub bb: [u64; 8],
     pub c: bool,
     pub halfm: u8,
     pub enp_sq: u8,

--- a/src/search.rs
+++ b/src/search.rs
@@ -309,7 +309,7 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
 
         // is a passed pawn move?
         let passed = usize::from(mov.pc) == Piece::PAWN
-            && SPANS[usize::from(pos.c)][usize::from(mov.from)] & pos.bb[Piece::PAWN] & pos.bb[usize::from(!pos.c)] > 0;
+            && SPANS[usize::from(pos.c)][usize::from(mov.from)] & pos.bb[Piece::PAWN] & pos.bb[usize::from(!pos.c)] == 0;
 
         // reductions
         let reduce = if can_lmr && ms < MoveScore::KILLER && !passed {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,7 @@
 use std::{sync::atomic::{AtomicU64, Ordering::Relaxed}, time::Instant};
-use super::{util::{Bound, Flag, MoveScore, Score}, position::{Move, MoveList, Position}};
+use crate::util::SPANS;
+
+use super::{util::{Bound, Flag, MoveScore, Piece, Score}, position::{Move, MoveList, Position}};
 
 pub static QNODES: AtomicU64 = AtomicU64::new(0);
 
@@ -305,8 +307,12 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
             quiets_tried.len += 1;
         }
 
+        // is a passed pawn move?
+        let passed = usize::from(mov.pc) == Piece::PAWN
+            && SPANS[usize::from(pos.c)][usize::from(mov.from)] & pos.bb[Piece::PAWN] & pos.bb[usize::from(!pos.c)] > 0;
+
         // reductions
-        let reduce = if can_lmr && ms < MoveScore::KILLER {
+        let reduce = if can_lmr && ms < MoveScore::KILLER && !passed {
             // late move reductions - Viridithas values used
             let mut r = (0.77 + lmr_base * (legal as f64).ln()) as i32;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -307,12 +307,8 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
             quiets_tried.len += 1;
         }
 
-        // is a passed pawn move?
-        let passed = usize::from(mov.pc) == Piece::PAWN
-            && SPANS[usize::from(pos.c)][usize::from(mov.from)] & pos.bb[Piece::PAWN] & pos.bb[usize::from(!pos.c)] == 0;
-
         // reductions
-        let reduce = if can_lmr && ms < MoveScore::KILLER && !passed {
+        let reduce = if can_lmr && ms < MoveScore::KILLER {
             // late move reductions - Viridithas values used
             let mut r = (0.77 + lmr_base * (legal as f64).ln()) as i32;
 
@@ -321,6 +317,11 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
 
             // reduce checks less
             r -= i32::from(new.check);
+
+            // reduce passed pawn moves less
+            let passed = usize::from(mov.pc) == Piece::PAWN
+                && SPANS[usize::from(pos.c)][usize::from(mov.from)] & pos.bb[Piece::PAWN] & pos.bb[usize::from(!pos.c)] == 0;
+            r -= i32::from(passed);
 
             // don't accidentally extend
             r.max(0)

--- a/src/util.rs
+++ b/src/util.rs
@@ -143,6 +143,14 @@ pub static ZVALS: ZobristVals = {
 };
 
 // Eval
+const FRONT_SPANS: [u64; 64] = init! {i, 64, {
+    let mut bb = (1 << i) << 8;
+    bb |= bb << 8;
+    bb |= bb << 16;
+    bb |= bb << 32;
+    bb | (bb & !File::H) << 1 | (bb & !File::A) >> 1
+}};
+pub const SPANS: [[u64; 64]; 2] = [FRONT_SPANS, init! {i, 64, FRONT_SPANS[i ^ 56].swap_bytes()}];
 pub const SIDE: [i32; 2] = [1, -1];
 pub const PHASE_VALS: [i32; 8] = [0, 0, 0, 1, 1, 2, 4, 0];
 pub static PST: [[[S; 64]; 8]; 2] = [


### PR DESCRIPTION
ELO   | 5.36 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16088 W: 5114 L: 4866 D: 6108
https://chess.swehosting.se/test/2140/

Bench: 6735522