### PR TITLE
Update Best Move only if Alpha Raised

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -342,7 +342,6 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
         // new best move
         if score <= best_score { continue }
         best_score = score;
-        best_move = mov;
 
         // update pv line
         if pv_node {
@@ -355,6 +354,7 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
 
         // improve alpha
         if score <= alpha { continue }
+        best_move = mov;
         alpha = score;
         bound = Bound::EXACT;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -343,6 +343,12 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
         if score <= best_score { continue }
         best_score = score;
 
+        // improve alpha
+        if score <= alpha { continue }
+        best_move = mov;
+        alpha = score;
+        bound = Bound::EXACT;
+
         // update pv line
         if pv_node {
             let sub_line = eng.pv_table[eng.ply as usize];
@@ -351,12 +357,6 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
             line.list[0] = mov;
             line.list[1..=sub_line.len].copy_from_slice(&sub_line.list[..sub_line.len]);
         }
-
-        // improve alpha
-        if score <= alpha { continue }
-        best_move = mov;
-        alpha = score;
-        bound = Bound::EXACT;
 
         // beta cutoff
         if score < beta { continue }


### PR DESCRIPTION
ELO   | 21.05 +- 10.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2760 W: 945 L: 778 D: 1037
https://chess.swehosting.se/test/2209/

Bench: 5722643