### PR TITLE
More History Penalty for Non-Best Quiet Moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -366,7 +366,7 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
         let bonus = (16 * depth.pow(2)).min(1200);
         eng.push_history(mov, pos.c, bonus);
         for &quiet in &quiets_tried.list[..quiets_tried.len - 1] {
-            eng.push_history(quiet, pos.c, -bonus / 2)
+            eng.push_history(quiet, pos.c, -bonus)
         }
 
         break


### PR DESCRIPTION
ELO   | 9.41 +- 6.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7088 W: 2286 L: 2094 D: 2708
https://chess.swehosting.se/test/2223/

Bench: 5190431