### PR TITLE
Quiet Late Move Pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -288,14 +288,20 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
     let (mut legal, mut bound) = (0, Bound::UPPER);
     let (mut best_score, mut best_move) = (-Score::MAX, tt_move);
     let mut quiets_tried = MoveList::default();
-    let can_lmp = !pv_node && !pos.check && depth < 4;
+    let can_lmp = !pv_node && !pos.check;
     let can_lmr = depth > 1 && eng.ply > 0 && !pos.check;
     let lmr_base = (depth as f64).ln() / 2.67;
 
     eng.push(hash);
     while let Some((mov, ms)) = moves.pick(&mut scores) {
         // late move pruning
-        if can_lmp && best_score.abs() < Score::MATE && legal > 10 * depth { break }
+        if can_lmp && best_score.abs() < Score::MATE {
+            // standard
+            if depth < 4 && legal > 10 * depth { break }
+
+            // quiet
+            if ms < MoveScore::KILLER && legal > 2 + depth * depth { break }
+        }
 
         let mut new = *pos;
 


### PR DESCRIPTION
ELO   | 14.86 +- 8.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4072 W: 1358 L: 1184 D: 1530
https://chess.swehosting.se/test/2233/

Bench: 3236412